### PR TITLE
feat(BrowserContext): add debugConsoleApi option to browser context

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -810,6 +810,13 @@ Whether to allow sites to register Service workers. Defaults to `'allow'`.
 * `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
 * `'block'`: Playwright will block all registration of Service Workers.
 
+## context-option-debugConsoleApi
+- `debugConsoleApi` <[boolean]>
+
+Whether to enable the Playwright console API in browser contexts. When enabled, provides access to `window.playwright` object with debugging helper methods. Defaults to `false`.
+
+This option is useful for debugging and can be enabled independently of debug mode. See [Browser Developer Tools](../debug.md#browser-developer-tools) for more details about the console API.
+
 ## remove-all-listeners-options-behavior
 * langs: js
 * since: v1.47
@@ -1002,6 +1009,7 @@ between the same pixel in compared images, between zero (strict) and one (lax), 
 - %%-context-option-recordvideo-size-%%
 - %%-context-option-strict-%%
 - %%-context-option-service-worker-policy-%%
+- %%-context-option-debugConsoleApi-%%
 
 ## browser-option-args
 - `args` <[Array]<[string]>>

--- a/packages/injected/src/consoleApi.ts
+++ b/packages/injected/src/consoleApi.ts
@@ -105,6 +105,10 @@ export class ConsoleAPI {
     delete this._injectedScript.window.playwright.or;
   }
 
+  uninstall() {
+    delete this._injectedScript.window.playwright;
+  }
+
   private _querySelector(selector: string, strict: boolean): (Element | undefined) {
     if (typeof selector !== 'string')
       throw new Error(`Usage: playwright.query('Playwright >> selector').`);

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -9800,6 +9800,15 @@ export interface Browser {
     contrast?: null|"no-preference"|"more";
 
     /**
+     * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+     * `window.playwright` object with debugging helper methods. Defaults to `false`.
+     *
+     * This option is useful for debugging and can be enabled independently of debug mode. See
+     * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+     */
+    debugConsoleApi?: boolean;
+
+    /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about
      * [emulating devices with device scale factor](https://playwright.dev/docs/emulation#devices).
      */
@@ -14883,6 +14892,15 @@ export interface BrowserType<Unused = {}> {
     contrast?: null|"no-preference"|"more";
 
     /**
+     * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+     * `window.playwright` object with debugging helper methods. Defaults to `false`.
+     *
+     * This option is useful for debugging and can be enabled independently of debug mode. See
+     * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+     */
+    debugConsoleApi?: boolean;
+
+    /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about
      * [emulating devices with device scale factor](https://playwright.dev/docs/emulation#devices).
      */
@@ -16708,6 +16726,15 @@ export interface AndroidDevice {
      * Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
      */
     contrast?: null|"no-preference"|"more";
+
+    /**
+     * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+     * `window.playwright` object with debugging helper methods. Defaults to `false`.
+     *
+     * This option is useful for debugging and can be enabled independently of debug mode. See
+     * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+     */
+    debugConsoleApi?: boolean;
 
     /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about
@@ -22128,6 +22155,15 @@ export interface BrowserContextOptions {
    * Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
    */
   contrast?: null|"no-preference"|"more";
+
+  /**
+   * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+   * `window.playwright` object with debugging helper methods. Defaults to `false`.
+   *
+   * This option is useful for debugging and can be enabled independently of debug mode. See
+   * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+   */
+  debugConsoleApi?: boolean;
 
   /**
    * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -641,6 +641,7 @@ scheme.BrowserTypeLaunchPersistentContextParams = tObject({
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
   selectorEngines: tOptional(tArray(tType('SelectorEngine'))),
   testIdAttributeName: tOptional(tString),
+  debugConsoleApi: tOptional(tBoolean),
   userDataDir: tString,
   slowMo: tOptional(tNumber),
 });
@@ -733,6 +734,7 @@ scheme.BrowserNewContextParams = tObject({
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
   selectorEngines: tOptional(tArray(tType('SelectorEngine'))),
   testIdAttributeName: tOptional(tString),
+  debugConsoleApi: tOptional(tBoolean),
   proxy: tOptional(tObject({
     server: tString,
     bypass: tOptional(tString),
@@ -804,6 +806,7 @@ scheme.BrowserNewContextForReuseParams = tObject({
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
   selectorEngines: tOptional(tArray(tType('SelectorEngine'))),
   testIdAttributeName: tOptional(tString),
+  debugConsoleApi: tOptional(tBoolean),
   proxy: tOptional(tObject({
     server: tString,
     bypass: tOptional(tString),
@@ -918,6 +921,7 @@ scheme.BrowserContextInitializer = tObject({
     serviceWorkers: tOptional(tEnum(['allow', 'block'])),
     selectorEngines: tOptional(tArray(tType('SelectorEngine'))),
     testIdAttributeName: tOptional(tString),
+    debugConsoleApi: tOptional(tBoolean),
   }),
 });
 scheme.BrowserContextBindingCallEvent = tObject({
@@ -2780,6 +2784,7 @@ scheme.AndroidDeviceLaunchBrowserParams = tObject({
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
   selectorEngines: tOptional(tArray(tType('SelectorEngine'))),
   testIdAttributeName: tOptional(tString),
+  debugConsoleApi: tOptional(tBoolean),
   pkg: tOptional(tString),
   args: tOptional(tArray(tString)),
   proxy: tOptional(tObject({

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -194,6 +194,8 @@ export abstract class BrowserContext extends SdkObject {
       if (oldDebugConsoleApi !== params.debugConsoleApi) {
         if (params.debugConsoleApi) {
           await this._installConsoleApi();
+        } else {
+          await this._removeConsoleApi();
         }
       }
     }
@@ -668,6 +670,13 @@ export abstract class BrowserContext extends SdkObject {
     await this.extendInjectedScript(`
       function installConsoleApi(injectedScript) { injectedScript.consoleApi.install(); }
       module.exports = { default: () => installConsoleApi };
+    `);
+  }
+
+  private async _removeConsoleApi() {
+    await this.extendInjectedScript(`
+      function uninstallConsoleApi(injectedScript) { injectedScript.consoleApi.uninstall(); }
+      module.exports = { default: () => uninstallConsoleApi };
     `);
   }
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -138,9 +138,8 @@ export abstract class BrowserContext extends SdkObject {
         RecorderApp.showInspectorNoReply(this);
     });
 
-    if (debugMode() === 'console' || this._options.debugConsoleApi) {
+    if (debugMode() === 'console' || this._options.debugConsoleApi)
       await this._installConsoleApi();
-    }
     if (this._options.serviceWorkers === 'block')
       await this.addInitScript(undefined, `\nif (navigator.serviceWorker) navigator.serviceWorker.register = async () => { console.warn('Service Worker registration blocked by Playwright'); };\n`);
 
@@ -189,14 +188,13 @@ export abstract class BrowserContext extends SdkObject {
         (this._options as any)[key] = params[key];
       if (params.testIdAttributeName)
         this.selectors().setTestIdAttributeName(params.testIdAttributeName);
-      
+
       // Handle debugConsoleApi option change
       if (oldDebugConsoleApi !== params.debugConsoleApi) {
-        if (params.debugConsoleApi) {
+        if (params.debugConsoleApi)
           await this._installConsoleApi();
-        } else {
+        else
           await this._removeConsoleApi();
-        }
       }
     }
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -139,10 +139,7 @@ export abstract class BrowserContext extends SdkObject {
     });
 
     if (debugMode() === 'console' || this._options.debugConsoleApi) {
-      await this.extendInjectedScript(`
-        function installConsoleApi(injectedScript) { injectedScript.consoleApi.install(); }
-        module.exports = { default: () => installConsoleApi };
-      `);
+      await this._installConsoleApi();
     }
     if (this._options.serviceWorkers === 'block')
       await this.addInitScript(undefined, `\nif (navigator.serviceWorker) navigator.serviceWorker.register = async () => { console.warn('Service Worker registration blocked by Playwright'); };\n`);
@@ -196,10 +193,7 @@ export abstract class BrowserContext extends SdkObject {
       // Handle debugConsoleApi option change
       if (oldDebugConsoleApi !== params.debugConsoleApi) {
         if (params.debugConsoleApi) {
-          await this.extendInjectedScript(`
-            function installConsoleApi(injectedScript) { injectedScript.consoleApi.install(); }
-            module.exports = { default: () => installConsoleApi };
-          `);
+          await this._installConsoleApi();
         }
       }
     }
@@ -668,6 +662,13 @@ export abstract class BrowserContext extends SdkObject {
     };
     this.on(BrowserContext.Events.Page, installInPage);
     return Promise.all(this.pages().map(installInPage));
+  }
+
+  private async _installConsoleApi() {
+    await this.extendInjectedScript(`
+      function installConsoleApi(injectedScript) { injectedScript.consoleApi.install(); }
+      module.exports = { default: () => installConsoleApi };
+    `);
   }
 
   async safeNonStallingEvaluateInAllFrames(expression: string, world: types.World, options: { throwOnJSErrors?: boolean } = {}) {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9800,6 +9800,15 @@ export interface Browser {
     contrast?: null|"no-preference"|"more";
 
     /**
+     * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+     * `window.playwright` object with debugging helper methods. Defaults to `false`.
+     *
+     * This option is useful for debugging and can be enabled independently of debug mode. See
+     * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+     */
+    debugConsoleApi?: boolean;
+
+    /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about
      * [emulating devices with device scale factor](https://playwright.dev/docs/emulation#devices).
      */
@@ -14883,6 +14892,15 @@ export interface BrowserType<Unused = {}> {
     contrast?: null|"no-preference"|"more";
 
     /**
+     * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+     * `window.playwright` object with debugging helper methods. Defaults to `false`.
+     *
+     * This option is useful for debugging and can be enabled independently of debug mode. See
+     * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+     */
+    debugConsoleApi?: boolean;
+
+    /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about
      * [emulating devices with device scale factor](https://playwright.dev/docs/emulation#devices).
      */
@@ -16708,6 +16726,15 @@ export interface AndroidDevice {
      * Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
      */
     contrast?: null|"no-preference"|"more";
+
+    /**
+     * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+     * `window.playwright` object with debugging helper methods. Defaults to `false`.
+     *
+     * This option is useful for debugging and can be enabled independently of debug mode. See
+     * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+     */
+    debugConsoleApi?: boolean;
 
     /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about
@@ -22128,6 +22155,15 @@ export interface BrowserContextOptions {
    * Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
    */
   contrast?: null|"no-preference"|"more";
+
+  /**
+   * Whether to enable the Playwright console API in browser contexts. When enabled, provides access to
+   * `window.playwright` object with debugging helper methods. Defaults to `false`.
+   *
+   * This option is useful for debugging and can be enabled independently of debug mode. See
+   * [Browser Developer Tools](https://playwright.dev/docs/debug#browser-developer-tools) for more details about the console API.
+   */
+  debugConsoleApi?: boolean;
 
   /**
    * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1055,6 +1055,7 @@ export type BrowserTypeLaunchPersistentContextParams = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   userDataDir: string,
   slowMo?: number,
 };
@@ -1138,6 +1139,7 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   slowMo?: number,
 };
 export type BrowserTypeLaunchPersistentContextResult = {
@@ -1259,6 +1261,7 @@ export type BrowserNewContextParams = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   proxy?: {
     server: string,
     bypass?: string,
@@ -1327,6 +1330,7 @@ export type BrowserNewContextOptions = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   proxy?: {
     server: string,
     bypass?: string,
@@ -1398,6 +1402,7 @@ export type BrowserNewContextForReuseParams = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   proxy?: {
     server: string,
     bypass?: string,
@@ -1466,6 +1471,7 @@ export type BrowserNewContextForReuseOptions = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   proxy?: {
     server: string,
     bypass?: string,
@@ -1601,6 +1607,7 @@ export type BrowserContextInitializer = {
     serviceWorkers?: 'allow' | 'block',
     selectorEngines?: SelectorEngine[],
     testIdAttributeName?: string,
+    debugConsoleApi?: boolean,
   },
 };
 export interface BrowserContextEventTarget {
@@ -4847,6 +4854,7 @@ export type AndroidDeviceLaunchBrowserParams = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   pkg?: string,
   args?: string[],
   proxy?: {
@@ -4913,6 +4921,7 @@ export type AndroidDeviceLaunchBrowserOptions = {
   serviceWorkers?: 'allow' | 'block',
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
+  debugConsoleApi?: boolean,
   pkg?: string,
   args?: string[],
   proxy?: {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -633,6 +633,7 @@ ContextOptions:
       type: array?
       items: SelectorEngine
     testIdAttributeName: string?
+    debugConsoleApi: boolean?
 
 
 LocalUtils:

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -398,10 +398,10 @@ it('should expose working console API when debugConsoleApi is true', async ({ br
   const context = await browser.newContext({ debugConsoleApi: true } as any);
   const page = await context.newPage();
   await page.setContent('<body></body>');
-  
+
   const bodyTag = await page.evaluate(() => (window as any).playwright.$('body').tagName);
   expect(bodyTag).toBe('BODY');
-  
+
   await context.close();
 });
 
@@ -409,10 +409,9 @@ it('should not expose console API by default', async ({ browser }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.setContent('<body></body>');
-  
+
   const hasPlaywrightAPI = await page.evaluate(() => typeof (window as any).playwright !== 'undefined');
   expect(hasPlaywrightAPI).toBe(false);
-  
+
   await context.close();
 });
-

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -415,3 +415,4 @@ it('should not expose console API by default', async ({ browser }) => {
   
   await context.close();
 });
+

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -393,3 +393,25 @@ it('should create two pages in parallel in various contexts', {
   ]);
   await context3.close();
 });
+
+it('should expose working console API when debugConsoleApi is true', async ({ browser }) => {
+  const context = await browser.newContext({ debugConsoleApi: true } as any);
+  const page = await context.newPage();
+  await page.setContent('<body></body>');
+  
+  const bodyTag = await page.evaluate(() => (window as any).playwright.$('body').tagName);
+  expect(bodyTag).toBe('BODY');
+  
+  await context.close();
+});
+
+it('should not expose console API by default', async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.setContent('<body></body>');
+  
+  const hasPlaywrightAPI = await page.evaluate(() => typeof (window as any).playwright !== 'undefined');
+  expect(hasPlaywrightAPI).toBe(false);
+  
+  await context.close();
+});

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -415,5 +415,33 @@ for (const scenario of ['launch', 'connect'] as const) {
       expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches)).toBe(true);
       await verifyViewport(page, 600, 800);
     });
+
+    test('should handle debugConsoleApi during context reuse', async ({ reusedContext }) => {
+      // Start without console API
+      let context = await reusedContext({ debugConsoleApi: false } as any);
+      let page = await context.newPage();
+      await page.setContent('<body></body>');
+      
+      // Verify API is not available
+      expect(await page.evaluate(() => typeof (window as any).playwright !== 'undefined')).toBe(false);
+      
+      // Reuse context with console API enabled
+      context = await reusedContext({ debugConsoleApi: true } as any);
+      page = context.pages()[0];
+      
+      // Verify API is now available after context reuse
+      expect(await page.evaluate(() => typeof (window as any).playwright !== 'undefined')).toBe(true);
+      
+      // Test that API works
+      const bodyTag = await page.evaluate(() => (window as any).playwright.$('body').tagName);
+      expect(bodyTag).toBe('BODY');
+      
+      // Reuse context with console API disabled again
+      context = await reusedContext({ debugConsoleApi: false } as any);
+      page = context.pages()[0];
+      
+      // Verify API is removed after context reuse
+      expect(await page.evaluate(() => typeof (window as any).playwright !== 'undefined')).toBe(false);
+    });
   });
 }

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -421,25 +421,25 @@ for (const scenario of ['launch', 'connect'] as const) {
       let context = await reusedContext({ debugConsoleApi: false } as any);
       let page = await context.newPage();
       await page.setContent('<body></body>');
-      
+
       // Verify API is not available
       expect(await page.evaluate(() => typeof (window as any).playwright !== 'undefined')).toBe(false);
-      
+
       // Reuse context with console API enabled
       context = await reusedContext({ debugConsoleApi: true } as any);
       page = context.pages()[0];
-      
+
       // Verify API is now available after context reuse
       expect(await page.evaluate(() => typeof (window as any).playwright !== 'undefined')).toBe(true);
-      
+
       // Test that API works
       const bodyTag = await page.evaluate(() => (window as any).playwright.$('body').tagName);
       expect(bodyTag).toBe('BODY');
-      
+
       // Reuse context with console API disabled again
       context = await reusedContext({ debugConsoleApi: false } as any);
       page = context.pages()[0];
-      
+
       // Verify API is removed after context reuse
       expect(await page.evaluate(() => typeof (window as any).playwright !== 'undefined')).toBe(false);
     });


### PR DESCRIPTION
 ## Summary
Adds a `debugConsoleApi` boolean option to browser context that enables programmatic access to the Playwright console API (`window.playwright.$`, `window.playwright.$$`, etc.) without requiring the `PWDEBUG=console` environment variable.

This allows enabling the debug console API on a per-context basis, providing more flexibility for testing and development workflows where you need selective access to the console API.

## Changes

- Add `debugConsoleApi?: boolean` option to `BrowserNewContextOptions`
- Update protocol definition in `protocol.yml` to include the new option
- Modify browser context initialization to inject console API when option is enabled
- Support the option in context reuse scenarios
- Add test coverage for both enabled and disabled scenarios

## Usage
```
  // Enable console API for this context
  const context = await browser.newContext({
  debugConsoleApi: true });
  const page = await context.newPage();

  // window.playwright is now available in the page
  await page.evaluate(() => {
    const element = window.playwright.$('body');
    console.log(element.tagName); // 'BODY'
  });
```

## Testing
Added tests to verify:
  - Console API is available when debugConsoleApi: true
  - Console API is not available by default
  - API functions work correctly when enabled
  - Context reuse properly handles the option

## Backward Compatibility

 This change should be fully backward compatible. The existing PWDEBUG=console environment variable continues to work unchanged. This option simply provides an additional programmatic way to enable the same functionality.